### PR TITLE
Force flag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,12 @@ program
     const username = databaseName;
     const userPwd = `${databaseName}-pwd`;
 
-    const confirmation = options.force === true || await confirm({
-      message: `This action will delete your database "${databaseName}" and cannot be reverted. Are you sure?`,
-      default: false,
-    });
+    const confirmation =
+      options.force === true ||
+      (await confirm({
+        message: `This action will delete your database "${databaseName}" and cannot be reverted. Are you sure?`,
+        default: false,
+      }));
 
     if (confirmation !== true) {
       console.info('Aborting...');
@@ -203,10 +205,12 @@ program
   .argument('<sql_file_path>', 'The SQL file to import')
   .option('-f,--force', 'Skip safety confirmation', false)
   .action(async (sqlFilePath, options) => {
-    const confirmation = options.force === true || await confirm({
-      message: 'This action will execute any SQL statement found in the given file and cannot be reverted. Are you sure?',
-      default: false,
-    });
+    const confirmation =
+      options.force === true ||
+      (await confirm({
+        message: 'This action will execute any SQL statement found in the given file and cannot be reverted. Are you sure?',
+        default: false,
+      }));
 
     if (confirmation !== true) {
       console.info('Aborting...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,11 +127,12 @@ program
   .command('drop')
   .description('Drops the given database and its default user (if they exist)')
   .argument('<db_name>', 'The database name')
-  .action(async (databaseName) => {
+  .option('-f,--force', 'Skip safety confirmation', false)
+  .action(async (databaseName, options) => {
     const username = databaseName;
     const userPwd = `${databaseName}-pwd`;
 
-    const confirmation = await confirm({
+    const confirmation = options.force === true || await confirm({
       message: `This action will delete your database "${databaseName}" and cannot be reverted. Are you sure?`,
       default: false,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,8 +201,9 @@ program
   .command('import')
   .description('Runs all queries from the given SQL file')
   .argument('<sql_file_path>', 'The SQL file to import')
-  .action(async (sqlFilePath) => {
-    const confirmation = await confirm({
+  .option('-f,--force', 'Skip safety confirmation', false)
+  .action(async (sqlFilePath, options) => {
+    const confirmation = options.force === true || await confirm({
       message: 'This action will execute any SQL statement found in the given file and cannot be reverted. Are you sure?',
       default: false,
     });


### PR DESCRIPTION
A new `-f` (`--force`) flag has been added to the following commands:
- `ldd drop DB_NAME -f`: adding the flag skips safety confirmation requests
- `ldd import SQL_FILE_NAME -f`: adding the flag skips safety confirmation requests

I intentionally avoided adding this flag to `ldd destroy` as that action can be very dangerous and I don't see any need to automate it or speed it up.