### PR TITLE
Adding support for project configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,34 @@ Stopping local database containers...
 
 ## Advanced configuration
 
+The goal of LDD is to speed up the process of setting up new projects and synchronizing a common system configuration across multiple environments. That's why we don't plan to support deep customization options.
+
+However, there are some common use cases that require a bit more flexibility, so the following features may help.
+
+### Project config file
+
+Each project usually requires its own database, and you will probably need to run most commands against it, depending on the project you are working on.
+
+The closest available `ldd.json` file is used to load the configuration for the current project:
+
+```json
+{
+  "dbName": "my-awesome-app"
+}
+```
+
+With the configuration above, any command will default to `my-awesome-app` as the `<db_name>` argument value if nothing is passed manually:
+
+```bash
+$ yarn ldd create
+Loading configuration from: /MyProjects/my-awesome-app/ldd.json
+Creating a new DB named "my-awesome-app"...
+
+# ...
+```
+
+### ENV variables
+
 We hope you never have to use them, but just in case, here are some ENV vars you can set on your machine to customize the behavior of the application:
 
 - `LDD_DB_IMAGE_TAG` (default: `latest`): we use the official [MariaDB](https://hub.docker.com/_/mariadb) Docker image. You can pick a different tag if you wish.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+const JSON_CONFIG_FILE_NAME = 'ldd.json';
+
+const DEFAULT_CONFIG: JsonConfiguration = {
+  dbName: undefined,
+};
+
+interface JsonConfiguration {
+  dbName?: string;
+}
+
+const findAndReadConfig = () => {
+  try {
+    let startdir = process.cwd();
+    let userConfigData = '{}';
+
+    while (true) {
+      var list = fs.readdirSync(startdir);
+
+      if (list.indexOf(JSON_CONFIG_FILE_NAME) != -1) {
+        // Found
+        console.info(`Loading configuration from: ${path.join(startdir, JSON_CONFIG_FILE_NAME)}`);
+
+        userConfigData = fs.readFileSync(path.join(startdir, JSON_CONFIG_FILE_NAME)).toString();
+        break;
+      } else if (startdir == '/') {
+        // Root dir, file not found
+        break;
+      } else {
+        startdir = path.normalize(path.join(startdir, '..'));
+      }
+    }
+
+    return {
+      ...DEFAULT_CONFIG,
+      ...JSON.parse(userConfigData),
+    } as JsonConfiguration;
+  } catch (e) {
+    console.error('ERROR: Failed reading LDD configuration file...');
+
+    process.exit(1);
+  }
+};
+
+export default findAndReadConfig();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ import { dockerCommand } from 'docker-cli-js';
 import mysql from 'mysql';
 
 import packageInfo from '../package.json';
+import config from './config';
 
-let PACKAGE_INSTALLATION_PATH = `${__dirname}/../..`;
+const PACKAGE_INSTALLATION_PATH = `${__dirname}/../..`;
 
 interface DockerImagesCommandResult {
   images: {
@@ -136,7 +137,7 @@ program
 program
   .command('create')
   .description('Creates a new database')
-  .argument('<db_name>', 'The database name')
+  .argument(config.dbName !== undefined ? '[db_name]' : '<db_name>', 'The database name', config.dbName)
   .action(async (databaseName) => {
     const username = databaseName;
     const userPwd = `${databaseName}-pwd`;
@@ -156,7 +157,7 @@ program
 program
   .command('drop')
   .description('Drops the given database and its default user (if they exist)')
-  .argument('<db_name>', 'The database name')
+  .argument(config.dbName !== undefined ? '[db_name]' : '<db_name>', 'The database name', config.dbName)
   .option('-f,--force', 'Skip safety confirmation', false)
   .action(async (databaseName, options) => {
     const username = databaseName;
@@ -207,7 +208,7 @@ program
 program
   .command('dump')
   .description('Creates a SQL dump file of the given database')
-  .argument('<db_name>', 'The database name')
+  .argument(config.dbName !== undefined ? '[db_name]' : '<db_name>', 'The database name', config.dbName)
   .action(async (databaseName) => {
     const now = new Date();
     const month = now.getMonth().toString().padStart(2, '0');


### PR DESCRIPTION
Use a `ldd.json` file to specify the database name for the current project.